### PR TITLE
chore: remove release channel config

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -7,14 +7,6 @@
       "openedTag": "1063924583847170098"
     },
 
-    "releaseAlertChannel": {
-      "id": ""
-    },
-    
-    "releaseChannel": {
-      "id": "984553991545446411"
-    },
-
     "emojis": {
       "coder": "971867583156469840",
       "linux": "1078434842309566575",

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -12,14 +12,6 @@ interface Config {
     openedTag: string;
   };
 
-  releaseAlertChannel: {
-    id: string;
-  };
-
-  releaseChannel: {
-    id: string;
-  };
-
   emojis: {
     coder: string;
     linux: string;
@@ -52,9 +44,6 @@ export const { config, layers } = await loadConfig<Config>({
     ["helpChannel", "id"],
     ["helpChannel", "closedTag"],
     ["helpChannel", "openedTag"],
-
-    ["releaseAlertChannel", "id"],
-    ["releaseChannel", "id"],
 
     ["emojis", "coder"],
     ["emojis", "linux"],


### PR DESCRIPTION
This is now handled by Zapier, so we don't need these anymore.