### PR TITLE
feat(walkthrough): mention /close and /reopen as command mentions

### DIFF
--- a/src/commands/util/walkthrough.ts
+++ b/src/commands/util/walkthrough.ts
@@ -6,6 +6,7 @@ import issueCategorySelector from "@components/issueCategorySelector.js";
 
 import {
   type ChatInputCommandInteraction,
+  type Client,
   SlashCommandBuilder,
   ActionRowBuilder,
   type StringSelectMenuBuilder,
@@ -25,7 +26,7 @@ import {
   type InteractionReplyOptions,
 } from "discord.js";
 
-function buildResourcesMessage(closeMention: string, reopenMention: string) {
+async function buildResourcesMessage(client: Client) {
   return {
     flags: MessageFlags.IsComponentsV2,
 
@@ -76,7 +77,7 @@ function buildResourcesMessage(closeMention: string, reopenMention: string) {
         .addSeparatorComponents(new SeparatorBuilder())
         .addTextDisplayComponents(
           new TextDisplayBuilder({
-            content: `When your issue is resolved, use ${closeMention} to close this post. Use ${reopenMention} to reopen it if needed.`,
+            content: `When your issue is resolved, use ${await getCommandMention(client, "close")} to close this post. Use ${await getCommandMention(client, "reopen")} to reopen it if needed.`,
           }),
         ),
     ],
@@ -106,10 +107,7 @@ export async function doWalkthrough(
   if (await isHelpThread(channel)) {
     const threadChannel = channel as PublicThreadChannel; // necessary type cast, isHelpThread does the check already
 
-    const resourcesMessage = buildResourcesMessage(
-      await getCommandMention(channel.client, "close"),
-      await getCommandMention(channel.client, "reopen"),
-    );
+    const resourcesMessage = await buildResourcesMessage(channel.client);
 
     // Check for tags in the forum post
     const appliedTags = threadChannel.appliedTags ?? [];

--- a/src/commands/util/walkthrough.ts
+++ b/src/commands/util/walkthrough.ts
@@ -1,6 +1,7 @@
 import { config } from "@lib/config.js";
 
 import { isHelpPost as isHelpThread } from "@lib/discord/channels.js";
+import { getCommandMention } from "@lib/discord/commands.js";
 import issueCategorySelector from "@components/issueCategorySelector.js";
 
 import {
@@ -24,52 +25,63 @@ import {
   type InteractionReplyOptions,
 } from "discord.js";
 
-const resourcesMessage = {
-  flags: MessageFlags.IsComponentsV2,
+function buildResourcesMessage(closeMention: string, reopenMention: string) {
+  return {
+    flags: MessageFlags.IsComponentsV2,
 
-  components: [
-    new ContainerBuilder().addSectionComponents([
-      new SectionBuilder()
-        .addTextDisplayComponents(
-          new TextDisplayBuilder({ content: "Where to find logs" }),
-        )
-        .setButtonAccessory(
-          new ButtonBuilder()
-            .setStyle(ButtonStyle.Link)
-            .setLabel("Docs")
-            .setURL("https://coder.com/docs/admin/monitoring/logs"),
-        ),
+    components: [
+      new ContainerBuilder()
+        .addSectionComponents([
+          new SectionBuilder()
+            .addTextDisplayComponents(
+              new TextDisplayBuilder({ content: "Where to find logs" }),
+            )
+            .setButtonAccessory(
+              new ButtonBuilder()
+                .setStyle(ButtonStyle.Link)
+                .setLabel("Docs")
+                .setURL("https://coder.com/docs/admin/monitoring/logs"),
+            ),
 
-      new SectionBuilder()
+          new SectionBuilder()
+            .addTextDisplayComponents(
+              new TextDisplayBuilder({
+                content: "Troubleshooting templates",
+              }),
+            )
+            .setButtonAccessory(
+              new ButtonBuilder()
+                .setStyle(ButtonStyle.Link)
+                .setLabel("Docs")
+                .setURL(
+                  "https://coder.com/docs/admin/templates/troubleshooting",
+                ),
+            ),
+
+          new SectionBuilder()
+            .addTextDisplayComponents(
+              new TextDisplayBuilder({
+                content: "Troubleshooting networking",
+              }),
+            )
+            .setButtonAccessory(
+              new ButtonBuilder()
+                .setStyle(ButtonStyle.Link)
+                .setLabel("Docs")
+                .setURL(
+                  "https://coder.com/docs/admin/networking/troubleshooting",
+                ),
+            ),
+        ])
+        .addSeparatorComponents(new SeparatorBuilder())
         .addTextDisplayComponents(
           new TextDisplayBuilder({
-            content: "Troubleshooting templates",
+            content: `When your issue is resolved, use ${closeMention} to close this post. Use ${reopenMention} to reopen it if needed.`,
           }),
-        )
-        .setButtonAccessory(
-          new ButtonBuilder()
-            .setStyle(ButtonStyle.Link)
-            .setLabel("Docs")
-            .setURL("https://coder.com/docs/admin/templates/troubleshooting"),
         ),
-
-      new SectionBuilder()
-        .addTextDisplayComponents(
-          new TextDisplayBuilder({
-            content: "Troubleshooting networking",
-          }),
-        )
-        .setButtonAccessory(
-          new ButtonBuilder()
-            .setStyle(ButtonStyle.Link)
-            .setLabel("Docs")
-            .setURL("https://coder.com/docs/admin/networking/troubleshooting"),
-        ),
-    ]),
-
-    new SeparatorBuilder(),
-  ],
-};
+    ],
+  };
+}
 
 export function generateQuestion(
   question: string,
@@ -93,6 +105,11 @@ export async function doWalkthrough(
 ) {
   if (await isHelpThread(channel)) {
     const threadChannel = channel as PublicThreadChannel; // necessary type cast, isHelpThread does the check already
+
+    const resourcesMessage = buildResourcesMessage(
+      await getCommandMention(channel.client, "close"),
+      await getCommandMention(channel.client, "reopen"),
+    );
 
     // Check for tags in the forum post
     const appliedTags = threadChannel.appliedTags ?? [];

--- a/src/lib/discord/commands.ts
+++ b/src/lib/discord/commands.ts
@@ -1,0 +1,19 @@
+import { config } from "@lib/config.js";
+
+import type { Client } from "discord.js";
+
+// Resolves a slash command mention (</name:id>) by looking the command ID up
+// from the ones the bot registered in the guild. Falls back to plain text if
+// the command cannot be found.
+export async function getCommandMention(
+  client: Client,
+  name: string,
+): Promise<string> {
+  const commands = await client.application.commands.fetch({
+    guildId: config.serverId,
+  });
+
+  const command = commands.find((cmd) => cmd.name === name);
+
+  return command ? `</${command.name}:${command.id}>` : `/${name}`;
+}


### PR DESCRIPTION
## What

The walkthrough resources message now points users at `/close` and `/reopen`, rendered as clickable Discord command mentions (`</name:id>`) instead of plain text.

## How

- Added `getCommandMention(client, name)` in `src/lib/discord/commands.ts`. It fetches the guild's registered application commands (`client.application.commands.fetch({ guildId })`) and returns `</name:id>`, falling back to `/name` if the command isn't found. The ID comes straight from the bot, nothing is hardcoded.
- Turned the static `resourcesMessage` into `buildResourcesMessage(closeMention, reopenMention)` and added a line to the resources card. `doWalkthrough` resolves both mentions before sending.

Commands are registered as guild commands, so the fetch is scoped to `config.serverId`.

## Notes

Placed the reference in the resources card shown on thread create. Happy to move it to the final pinned embed instead if preferred.

---
_Opened by Coder Agents on behalf of @phorcys420._