### PR TITLE
feat(src): auto-set waiting-for-user/team tags on help posts

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -4,8 +4,14 @@
     "helpChannel": {
       "closedTag": "1006926031434813500",
       "id": "1006346052317753414",
-      "openedTag": "1409314109773582487"
+      "openedTag": "1409314109773582487",
+      "waitingForUserTag": "1382030514571186327",
+      "waitingForTeamTag": "1536933491315314868"
     },
+
+    "teamRoleId": "776843361662271568",
+
+    "startupCatchupLimit": 20,
 
     "emojis": {
       "coder": "1387459034508034058",

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -10,6 +10,7 @@ import { default as product_notes } from "./product/notes.js";
 
 import { default as close } from "./util/close.js";
 import { default as reopen } from "./util/reopen.js";
+import { default as updateThread } from "./util/update-thread.js";
 import { default as walkthrough } from "./util/walkthrough.js";
 
 type AnyCommandBuilder =
@@ -27,7 +28,13 @@ const commandObject: {
   };
 } = {};
 
-for (const command of [product_notes, close, reopen, walkthrough]) {
+for (const command of [
+  product_notes,
+  close,
+  reopen,
+  updateThread,
+  walkthrough,
+]) {
   commandObject[command.data.name] = command;
 }
 

--- a/src/commands/util/update-thread.ts
+++ b/src/commands/util/update-thread.ts
@@ -1,0 +1,51 @@
+import { config } from "@lib/config.js";
+import {
+  getChannelFromInteraction,
+  isHelpPost,
+} from "@lib/discord/channels.js";
+import { reconcileThread } from "@lib/discord/help.js";
+
+import {
+  type ChatInputCommandInteraction,
+  type ThreadChannel,
+  MessageFlags,
+  PermissionFlagsBits,
+  SlashCommandBuilder,
+} from "discord.js";
+
+export default {
+  data: new SlashCommandBuilder()
+    .setName("update-thread")
+    .setDescription(
+      "Re-sync this help post's waiting tag with the last message",
+    )
+    .setDefaultMemberPermissions(PermissionFlagsBits.ManageChannels),
+
+  execute: async (interaction: ChatInputCommandInteraction) => {
+    const channel = await getChannelFromInteraction(interaction);
+
+    if (!(await isHelpPost(channel))) {
+      await interaction.reply({
+        content: `You can only run this command in a <#${config.helpChannel.id}> post.`,
+        flags: [MessageFlags.Ephemeral],
+      });
+      return;
+    }
+
+    const member = await interaction.guild.members.fetch(interaction.user.id);
+    if (!member.permissions.has(PermissionFlagsBits.ManageChannels)) {
+      await interaction.reply({
+        content: "You do not have permission to run this command.",
+        flags: [MessageFlags.Ephemeral],
+      });
+      return;
+    }
+
+    await reconcileThread(channel as ThreadChannel);
+
+    await interaction.reply({
+      content: "Updated this post's waiting tag.",
+      flags: [MessageFlags.Ephemeral],
+    });
+  },
+};

--- a/src/events/messages.ts
+++ b/src/events/messages.ts
@@ -1,5 +1,8 @@
 import { type Client, Events, MessageType } from "discord.js";
 
+import { isHelpPost } from "@lib/discord/channels.js";
+import { reconcileFromMessage } from "@lib/discord/help.js";
+
 export default function registerEvents(client: Client) {
   return client.on(Events.MessageCreate, async (message) => {
     // If the bot pins a message, then we delete the automatic announcement message
@@ -8,6 +11,12 @@ export default function registerEvents(client: Client) {
       message.author.id === client.user.id
     ) {
       await message.delete();
+      return;
+    }
+
+    // Keep the help post's waiting tag in sync with the latest interaction.
+    if (message.inGuild() && (await isHelpPost(message.channel))) {
+      await reconcileFromMessage(message);
     }
   });
 }

--- a/src/events/messages.ts
+++ b/src/events/messages.ts
@@ -14,7 +14,7 @@ export default function registerEvents(client: Client) {
       return;
     }
 
-    // Keep the help post's waiting tag in sync with the latest interaction.
+    // Keep the help posts' waiting tag in sync with the latest interaction.
     if (message.inGuild() && (await isHelpPost(message.channel))) {
       await reconcileFromMessage(message);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { config } from "./lib/config.js";
+import { catchUpHelpPosts } from "./lib/discord/help.js";
 
 import registerCommandEvents from "./events/commands.js";
 import registerWalkthroughEvents from "./events/walkthrough.js";
@@ -42,6 +43,10 @@ client.once(Events.ClientReady, () => {
 
   shufflePresence();
   setInterval(shufflePresence, config.presenceDelay);
+
+  catchUpHelpPosts(client).catch((err) =>
+    console.error("Failed to catch up on help posts:", err),
+  );
 });
 
 client.login(config.token);

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -10,7 +10,17 @@ interface Config {
 
     closedTag: string;
     openedTag: string;
+
+    waitingForUserTag: string;
+    waitingForTeamTag: string;
   };
+
+  // Role that identifies Coder team members. Anyone without this role is
+  // treated as a community member.
+  teamRoleId: string;
+
+  // Number of most recently active open help posts to reconcile on startup.
+  startupCatchupLimit: number;
 
   emojis: {
     coder: string;
@@ -40,6 +50,7 @@ export const { config, layers } = await loadConfig<Config>({
 
   defaults: {
     presenceDelay: 10 * 60 * 1000,
+    startupCatchupLimit: 20,
   },
   mandatory: [
     "token",
@@ -49,6 +60,10 @@ export const { config, layers } = await loadConfig<Config>({
     ["helpChannel", "id"],
     ["helpChannel", "closedTag"],
     ["helpChannel", "openedTag"],
+    ["helpChannel", "waitingForUserTag"],
+    ["helpChannel", "waitingForTeamTag"],
+
+    "teamRoleId",
 
     ["emojis", "coder"],
     ["emojis", "linux"],

--- a/src/lib/discord/help.ts
+++ b/src/lib/discord/help.ts
@@ -60,15 +60,19 @@ async function resolveMember(message: Message): Promise<GuildMember | null> {
   }
 }
 
+// Applies the waiting tag for a help post based on who sent the given message.
+async function applyWaitingTagFromMessage(
+  thread: ThreadChannel,
+  message: Message,
+): Promise<void> {
+  const member = await resolveMember(message);
+  await applyWaitingTag(thread, member ? isTeamMember(member) : false);
+}
+
 // Reconciles a single help post from a freshly received message.
 export async function reconcileFromMessage(message: Message): Promise<void> {
   if (!isHumanMessage(message)) return;
-
-  const member = await resolveMember(message);
-  await applyWaitingTag(
-    message.channel as ThreadChannel,
-    member ? isTeamMember(member) : false,
-  );
+  await applyWaitingTagFromMessage(message.channel as ThreadChannel, message);
 }
 
 // Reconciles a help post by inspecting its most recent human message.
@@ -76,9 +80,7 @@ export async function reconcileThread(thread: ThreadChannel): Promise<void> {
   const messages = await thread.messages.fetch({ limit: 10 });
   const lastHuman = messages.find(isHumanMessage);
   if (!lastHuman) return;
-
-  const member = await resolveMember(lastHuman);
-  await applyWaitingTag(thread, member ? isTeamMember(member) : false);
+  await applyWaitingTagFromMessage(thread, lastHuman);
 }
 
 // On startup, reconcile the most recently active open help posts so their

--- a/src/lib/discord/help.ts
+++ b/src/lib/discord/help.ts
@@ -72,7 +72,7 @@ export async function reconcileFromMessage(message: Message): Promise<void> {
 }
 
 // Reconciles a help post by inspecting its most recent human message.
-async function reconcileThread(thread: ThreadChannel): Promise<void> {
+export async function reconcileThread(thread: ThreadChannel): Promise<void> {
   const messages = await thread.messages.fetch({ limit: 10 });
   const lastHuman = messages.find(isHumanMessage);
   if (!lastHuman) return;

--- a/src/lib/discord/help.ts
+++ b/src/lib/discord/help.ts
@@ -1,0 +1,107 @@
+import { config } from "@lib/config.js";
+import { isTeamMember } from "@lib/discord/users.js";
+
+import {
+  type Client,
+  type GuildMember,
+  type Message,
+  type ThreadChannel,
+  ChannelType,
+  MessageType,
+} from "discord.js";
+
+// Message types that represent an actual interaction from a person, as opposed
+// to system notices (pins, joins, etc).
+const humanMessageTypes = new Set([MessageType.Default, MessageType.Reply]);
+
+function isHumanMessage(message: Message): boolean {
+  return !message.author.bot && humanMessageTypes.has(message.type);
+}
+
+// Picks the waiting tag for a help post based on who sent the last message.
+// When the last interaction comes from a community member the team still needs
+// to respond, so we apply waitingForTeamTag; when it comes from the Coder team
+// we apply waitingForUserTag. Adding one always removes the other.
+export async function applyWaitingTag(
+  thread: ThreadChannel,
+  lastFromTeam: boolean,
+): Promise<void> {
+  const { waitingForUserTag, waitingForTeamTag, closedTag } =
+    config.helpChannel;
+
+  // Leave closed posts untouched.
+  if (thread.appliedTags.includes(closedTag)) return;
+
+  const desired = lastFromTeam ? waitingForUserTag : waitingForTeamTag;
+  const opposite = lastFromTeam ? waitingForTeamTag : waitingForUserTag;
+
+  const alreadyCorrect =
+    thread.appliedTags.includes(desired) &&
+    !thread.appliedTags.includes(opposite);
+  if (alreadyCorrect) return;
+
+  // Forum posts allow at most 5 tags. Keep the desired tag and drop the
+  // opposite one, trimming any overflow from the least recent tags.
+  const nextTags = [
+    desired,
+    ...thread.appliedTags.filter((t) => t !== desired && t !== opposite),
+  ].slice(0, 5);
+
+  await thread.setAppliedTags(nextTags, "Help post waiting state");
+}
+
+async function resolveMember(message: Message): Promise<GuildMember | null> {
+  if (message.member) return message.member;
+
+  try {
+    return await message.guild?.members.fetch(message.author.id);
+  } catch {
+    return null;
+  }
+}
+
+// Reconciles a single help post from a freshly received message.
+export async function reconcileFromMessage(message: Message): Promise<void> {
+  if (!isHumanMessage(message)) return;
+
+  const member = await resolveMember(message);
+  await applyWaitingTag(
+    message.channel as ThreadChannel,
+    member ? isTeamMember(member) : false,
+  );
+}
+
+// Reconciles a help post by inspecting its most recent human message.
+async function reconcileThread(thread: ThreadChannel): Promise<void> {
+  const messages = await thread.messages.fetch({ limit: 10 });
+  const lastHuman = messages.find(isHumanMessage);
+  if (!lastHuman) return;
+
+  const member = await resolveMember(lastHuman);
+  await applyWaitingTag(thread, member ? isTeamMember(member) : false);
+}
+
+// On startup, reconcile the most recently active open help posts so their
+// waiting tag reflects the last interaction even if messages were missed while
+// the bot was offline.
+export async function catchUpHelpPosts(client: Client): Promise<void> {
+  const forum = await client.channels.fetch(config.helpChannel.id);
+  if (!forum || forum.type !== ChannelType.GuildForum) return;
+
+  const { threads } = await forum.threads.fetchActive();
+
+  const openPosts = [...threads.values()]
+    .filter((t) => !t.appliedTags.includes(config.helpChannel.closedTag))
+    .sort((a, b) =>
+      (b.lastMessageId ?? "").localeCompare(a.lastMessageId ?? ""),
+    )
+    .slice(0, config.startupCatchupLimit);
+
+  for (const thread of openPosts) {
+    try {
+      await reconcileThread(thread);
+    } catch (err) {
+      console.error(`Failed to reconcile help post ${thread.id}:`, err);
+    }
+  }
+}

--- a/src/lib/discord/users.ts
+++ b/src/lib/discord/users.ts
@@ -1,3 +1,13 @@
+import { config } from "@lib/config.js";
+
+import type { GuildMember } from "discord.js";
+
 export function getClientIDFromToken(token: string): string {
   return atob(token.split(".")[0]);
+}
+
+// A member is part of the Coder team if they hold the configured team role.
+// Everyone else is treated as a community member.
+export function isTeamMember(member: GuildMember): boolean {
+  return member.roles.cache.has(config.teamRoleId);
 }


### PR DESCRIPTION
Keeps a waiting tag in sync with the last interaction on `#help` forum posts.

## Behavior
- On `MessageCreate` in a help post, apply the correct waiting tag based on who sent the message:
  - community member's message -> `waiting-for-team`
  - Coder team member's message -> `waiting-for-user`
- Adding one waiting tag always removes the other. Closed posts, bots, and system messages are ignored, and the forum 5-tag cap is respected.
- On startup, reconcile the most recently active open help posts (from `fetchActive`, capped by `startupCatchupLimit`) so state missed while offline is recovered. Archived/closed posts are skipped.

## Config
New options (see `config.json.example`):
- `helpChannel.waitingForUserTag`, `helpChannel.waitingForTeamTag`
- `teamRoleId` (mandatory): members with this role are Coder team; everyone else is community.
- `startupCatchupLimit` (default `20`).

<details>
<summary>Decision log</summary>

- Team membership is resolved from a single configurable role (`teamRoleId`) rather than the existing `ManageChannels` permission proxy, to match the "Coder team vs community" distinction explicitly.
- The initial spec wording mapped community->waiting-for-user and team->waiting-for-team; confirmed with the requester that this was inverted and implemented the support-flow semantics above.
- "Catch up on the last couple open tags on startup" is implemented as reconciling active (non-archived) open posts only, capped by `startupCatchupLimit`.
- `applyWaitingTag` centralizes the mapping so the direction is a single point of change.

</details>

---
_Opened by Coder Agents on behalf of @phorcys420._