### PR TITLE
fix(walkthrough): don't send question when walkthrough already exists

### DIFF
--- a/src/commands/util/walkthrough.ts
+++ b/src/commands/util/walkthrough.ts
@@ -138,10 +138,11 @@ export async function doWalkthrough(
           content: `You cannot run the walkthrough command because a walkthrough already exists in this channel.\n(${walkthroughMessage.url})`,
           ephemeral: true,
         });
-      } else {
-        // TODO: fix the fact that it looks weird when the resources message is sent as a reply
-        await interaction.reply(resourcesMessage as InteractionReplyOptions);
+        return;
       }
+
+      // TODO: fix the fact that it looks weird when the resources message is sent as a reply
+      await interaction.reply(resourcesMessage as InteractionReplyOptions);
     } else {
       await channel.send(resourcesMessage as MessageCreateOptions);
     }


### PR DESCRIPTION
## Problem

Running `/walkthrough` in a help thread that already has a walkthrough replies with the "a walkthrough already exists in this channel" error, but then still posts the "What are you creating this issue for?" question anyway.

## Cause

`doWalkthrough` has no early return after the error reply. Both branches of the `if (interaction)` block fall through to the `channel.send(message)` at the end that sends the issue-category question.

## Fix

Return right after the "already exists" reply so the duplicate question is never sent. The now-dead `else` around the resources reply is dropped.

---

🤖 Generated with Coder Agents on behalf of @phorcys420.