### PR TITLE
feat(commands/util): tell users how to reopen and use issue verbiage

### DIFF
--- a/src/commands/util/close.ts
+++ b/src/commands/util/close.ts
@@ -5,6 +5,7 @@ import {
   getChannelFromInteraction,
   isHelpPost,
 } from "@lib/discord/channels.js";
+import { getCommandMention } from "@lib/discord/commands.js";
 
 import {
   type ThreadChannel,
@@ -56,8 +57,15 @@ export async function handleIssueState(
 
     await threadChannel.setAppliedTags(postTags, "Thread lifecycle");
 
+    const reopenHint = close
+      ? ` You can reopen this issue by doing ${await getCommandMention(
+          interaction.client,
+          "reopen",
+        )}.`
+      : "";
+
     await interaction.reply({
-      content: `${interaction.user.toString()} ${stateWord} ${lock ? "and locked " : ""}the thread.`,
+      content: `${interaction.user.toString()} ${stateWord} ${lock ? "and locked " : ""}the thread.${reopenHint}`,
       flags: [MessageFlags.SuppressNotifications],
     });
 
@@ -108,7 +116,7 @@ export async function handleIssueStateCommand(
     }
   } else {
     await interaction.reply({
-      content: `You can only run this command in a <#${config.helpChannel.id}> post.`,
+      content: `You can only run this command in a <#${config.helpChannel.id}> issue.`,
       ephemeral: true,
     });
   }
@@ -117,9 +125,9 @@ export async function handleIssueStateCommand(
 export default {
   data: new SlashCommandBuilder()
     .setName("close")
-    .setDescription("Closes your post")
+    .setDescription("Closes your issue")
     .addBooleanOption((option) =>
-      option.setName("lock").setDescription("Whether to lock the post or not"),
+      option.setName("lock").setDescription("Whether to lock the issue or not"),
     ),
 
   execute: (interaction: ChatInputCommandInteraction) =>

--- a/src/commands/util/reopen.ts
+++ b/src/commands/util/reopen.ts
@@ -8,7 +8,7 @@ import {
 export default {
   data: new SlashCommandBuilder()
     .setName("reopen")
-    .setDescription("Reopens your post"),
+    .setDescription("Reopens your issue"),
 
   execute: (interaction: ChatInputCommandInteraction) =>
     handleIssueStateCommand(interaction, false, false),


### PR DESCRIPTION
## What

- Running `/close` now tells the user how to reopen: the reply appends "You can reopen this issue by doing `/reopen`", with `/reopen` rendered as a clickable command mention.
- User-facing command copy now says "issue" instead of "post".

## Details

- The reopen hint is only added when closing, not when reopening.
- Renamed "post" to "issue" in the `/close` and `/reopen` command descriptions, the lock option description, and the "run this command in a ... issue" error.

---
_Opened by Coder Agents on behalf of @phorcys420._