### PR TITLE
feat(src/events/channels): tag new help posts waiting-for-team

### DIFF
--- a/src/events/channels.ts
+++ b/src/events/channels.ts
@@ -1,6 +1,7 @@
 import { config } from "../lib/config.js";
 import { getTagsForCloseState } from "../commands/util/close.js";
 import { isHelpPost } from "../lib/discord/channels.js";
+import { applyWaitingTag } from "../lib/discord/help.js";
 
 import { debounce } from "throttle-debounce";
 
@@ -64,6 +65,15 @@ const handleEvent = debounce(
 );
 
 export default function registerEvents(client: Client) {
+  client.on(Events.ThreadCreate, async (thread) => {
+    if (!(await isHelpPost(thread))) {
+      return;
+    }
+
+    // A new help post is waiting for the Coder team to respond.
+    await applyWaitingTag(thread, false);
+  });
+
   client.on(Events.ThreadUpdate, async (oldThread, newThread) => {
     if (!(await isHelpPost(newThread))) {
       return;


### PR DESCRIPTION
Follow-up to #46. Tags a help post `waiting-for-team` as soon as it's created, so it shows up in the team's queue before anyone sends a follow-up message.

## Behavior
- On `ThreadCreate` in the help forum, apply `waitingForTeamTag` via the existing `applyWaitingTag(thread, false)` path (closed-post skip and the 5-tag cap still apply).
- Handled on `ThreadCreate` rather than relying on the starter message, since the forum post's initial message does not reliably emit `MessageCreate`.

---
_Opened by Coder Agents on behalf of @phorcys420._