### PR TITLE
fix(help): keep open/closed tags first on forum posts

### DIFF
--- a/src/commands/util/close.ts
+++ b/src/commands/util/close.ts
@@ -5,7 +5,6 @@ import {
   getChannelFromInteraction,
   isHelpPost,
 } from "@lib/discord/channels.js";
-import { getCommandMention } from "@lib/discord/commands.js";
 import { orderAppliedTags } from "@lib/discord/tags.js";
 
 import {
@@ -54,15 +53,8 @@ export async function handleIssueState(
 
     await threadChannel.setAppliedTags(nextTags, "Thread lifecycle");
 
-    const reopenHint = close
-      ? ` You can reopen this issue by doing ${await getCommandMention(
-          interaction.client,
-          "reopen",
-        )}.`
-      : "";
-
     await interaction.reply({
-      content: `${interaction.user.toString()} ${stateWord} ${lock ? "and locked " : ""}the thread.${reopenHint}`,
+      content: `${interaction.user.toString()} ${stateWord} ${lock ? "and locked " : ""}the thread.`,
       flags: [MessageFlags.SuppressNotifications],
     });
 
@@ -81,7 +73,7 @@ export async function handleIssueState(
   } catch (e) {
     await interaction.reply({
       content: `Could not ${stateVerb} the thread because of an unexpected error.`,
-      ephemeral: true,
+      flags: [MessageFlags.Ephemeral],
     });
   }
 }
@@ -108,13 +100,13 @@ export async function handleIssueStateCommand(
     } else {
       await interaction.reply({
         content: `You cannot ${stateVerb} this thread since you are not the OP.`,
-        ephemeral: true,
+        flags: [MessageFlags.Ephemeral],
       });
     }
   } else {
     await interaction.reply({
-      content: `You can only run this command in a <#${config.helpChannel.id}> issue.`,
-      ephemeral: true,
+      content: `You can only run this command in a <#${config.helpChannel.id}> post.`,
+      flags: [MessageFlags.Ephemeral],
     });
   }
 }
@@ -122,9 +114,9 @@ export async function handleIssueStateCommand(
 export default {
   data: new SlashCommandBuilder()
     .setName("close")
-    .setDescription("Closes your issue")
+    .setDescription("Closes your post")
     .addBooleanOption((option) =>
-      option.setName("lock").setDescription("Whether to lock the issue or not"),
+      option.setName("lock").setDescription("Whether to lock the post or not"),
     ),
 
   execute: (interaction: ChatInputCommandInteraction) =>

--- a/src/commands/util/close.ts
+++ b/src/commands/util/close.ts
@@ -5,6 +5,8 @@ import {
   getChannelFromInteraction,
   isHelpPost,
 } from "@lib/discord/channels.js";
+import { getCommandMention } from "@lib/discord/commands.js";
+import { orderAppliedTags } from "@lib/discord/tags.js";
 
 import {
   type ThreadChannel,
@@ -42,22 +44,25 @@ export async function handleIssueState(
 
   const { tagToAdd, tagToRemove } = getTagsForCloseState(close);
 
-  const postTags = threadChannel.appliedTags;
-
   try {
-    // Update tags
-    if (!postTags.includes(tagToAdd)) {
-      postTags.push(tagToAdd);
-    }
+    // Add the target state tag, drop its opposite, and reorder so status
+    // tags follow the channel's configured order (open/closed first).
+    const nextTags = orderAppliedTags(threadChannel, [
+      ...threadChannel.appliedTags.filter((t) => t !== tagToRemove),
+      tagToAdd,
+    ]);
 
-    if (postTags.includes(tagToRemove)) {
-      postTags.splice(postTags.indexOf(tagToRemove), 1);
-    }
+    await threadChannel.setAppliedTags(nextTags, "Thread lifecycle");
 
-    await threadChannel.setAppliedTags(postTags, "Thread lifecycle");
+    const reopenHint = close
+      ? ` You can reopen this issue by doing ${await getCommandMention(
+          interaction.client,
+          "reopen",
+        )}.`
+      : "";
 
     await interaction.reply({
-      content: `${interaction.user.toString()} ${stateWord} ${lock ? "and locked " : ""}the thread.`,
+      content: `${interaction.user.toString()} ${stateWord} ${lock ? "and locked " : ""}the thread.${reopenHint}`,
       flags: [MessageFlags.SuppressNotifications],
     });
 
@@ -76,7 +81,7 @@ export async function handleIssueState(
   } catch (e) {
     await interaction.reply({
       content: `Could not ${stateVerb} the thread because of an unexpected error.`,
-      flags: [MessageFlags.Ephemeral],
+      ephemeral: true,
     });
   }
 }
@@ -103,13 +108,13 @@ export async function handleIssueStateCommand(
     } else {
       await interaction.reply({
         content: `You cannot ${stateVerb} this thread since you are not the OP.`,
-        flags: [MessageFlags.Ephemeral],
+        ephemeral: true,
       });
     }
   } else {
     await interaction.reply({
-      content: `You can only run this command in a <#${config.helpChannel.id}> post.`,
-      flags: [MessageFlags.Ephemeral],
+      content: `You can only run this command in a <#${config.helpChannel.id}> issue.`,
+      ephemeral: true,
     });
   }
 }
@@ -117,9 +122,9 @@ export async function handleIssueStateCommand(
 export default {
   data: new SlashCommandBuilder()
     .setName("close")
-    .setDescription("Closes your post")
+    .setDescription("Closes your issue")
     .addBooleanOption((option) =>
-      option.setName("lock").setDescription("Whether to lock the post or not"),
+      option.setName("lock").setDescription("Whether to lock the issue or not"),
     ),
 
   execute: (interaction: ChatInputCommandInteraction) =>

--- a/src/commands/util/walkthrough.ts
+++ b/src/commands/util/walkthrough.ts
@@ -141,7 +141,7 @@ export async function doWalkthrough(
       if (walkthroughMessage) {
         await interaction.reply({
           content: `You cannot run the walkthrough command because a walkthrough already exists in this channel.\n(${walkthroughMessage.url})`,
-          ephemeral: true,
+          flags: MessageFlags.Ephemeral,
         });
         return;
       }

--- a/src/commands/util/walkthrough.ts
+++ b/src/commands/util/walkthrough.ts
@@ -2,6 +2,7 @@ import { config } from "@lib/config.js";
 
 import { isHelpPost as isHelpThread } from "@lib/discord/channels.js";
 import { getCommandMention } from "@lib/discord/commands.js";
+import { orderAppliedTags } from "@lib/discord/tags.js";
 import issueCategorySelector from "@components/issueCategorySelector.js";
 
 import {
@@ -112,8 +113,12 @@ export async function doWalkthrough(
     // Check for tags in the forum post
     const appliedTags = threadChannel.appliedTags ?? [];
     if (!appliedTags.includes(config.helpChannel.openedTag)) {
-      appliedTags.push(config.helpChannel.openedTag);
-      threadChannel.setAppliedTags(appliedTags);
+      await threadChannel.setAppliedTags(
+        orderAppliedTags(threadChannel, [
+          ...appliedTags,
+          config.helpChannel.openedTag,
+        ]),
+      );
     }
 
     // Send the resources message (or reply to the user if they're running the command)
@@ -136,7 +141,7 @@ export async function doWalkthrough(
       if (walkthroughMessage) {
         await interaction.reply({
           content: `You cannot run the walkthrough command because a walkthrough already exists in this channel.\n(${walkthroughMessage.url})`,
-          flags: MessageFlags.Ephemeral,
+          ephemeral: true,
         });
         return;
       }

--- a/src/events/channels.ts
+++ b/src/events/channels.ts
@@ -1,6 +1,7 @@
 import { config } from "../lib/config.js";
 import { getTagsForCloseState } from "../commands/util/close.js";
 import { isHelpPost } from "../lib/discord/channels.js";
+import { applyWaitingTag } from "../lib/discord/help.js";
 import { orderAppliedTags } from "../lib/discord/tags.js";
 
 import { debounce } from "throttle-debounce";
@@ -70,6 +71,15 @@ const handleEvent = debounce(
 );
 
 export default function registerEvents(client: Client) {
+  client.on(Events.ThreadCreate, async (thread) => {
+    if (!(await isHelpPost(thread))) {
+      return;
+    }
+
+    // A new help post is waiting for the Coder team to respond.
+    await applyWaitingTag(thread, false);
+  });
+
   client.on(Events.ThreadUpdate, async (oldThread, newThread) => {
     if (!(await isHelpPost(newThread))) {
       return;

--- a/src/events/channels.ts
+++ b/src/events/channels.ts
@@ -1,7 +1,7 @@
 import { config } from "../lib/config.js";
 import { getTagsForCloseState } from "../commands/util/close.js";
 import { isHelpPost } from "../lib/discord/channels.js";
-import { applyWaitingTag } from "../lib/discord/help.js";
+import { orderAppliedTags } from "../lib/discord/tags.js";
 
 import { debounce } from "throttle-debounce";
 
@@ -35,7 +35,10 @@ const handleEvent = debounce(
           const { tagToRemove } = getTagsForCloseState(isClose);
           if (newThread.appliedTags.includes(tagToRemove)) {
             await newThread.setAppliedTags(
-              newThread.appliedTags.filter((t) => t !== tagToRemove),
+              orderAppliedTags(
+                newThread,
+                newThread.appliedTags.filter((t) => t !== tagToRemove),
+              ),
             );
           }
         }
@@ -56,7 +59,9 @@ const handleEvent = debounce(
           const isClose = tag === config.helpChannel.closedTag;
           const { tagToRemove } = getTagsForCloseState(isClose);
           if (!newThread.appliedTags.includes(tagToRemove)) {
-            await newThread.setAppliedTags([...newThread.appliedTags, tag]);
+            await newThread.setAppliedTags(
+              orderAppliedTags(newThread, [...newThread.appliedTags, tag]),
+            );
           }
         }
       }
@@ -65,15 +70,6 @@ const handleEvent = debounce(
 );
 
 export default function registerEvents(client: Client) {
-  client.on(Events.ThreadCreate, async (thread) => {
-    if (!(await isHelpPost(thread))) {
-      return;
-    }
-
-    // A new help post is waiting for the Coder team to respond.
-    await applyWaitingTag(thread, false);
-  });
-
   client.on(Events.ThreadUpdate, async (oldThread, newThread) => {
     if (!(await isHelpPost(newThread))) {
       return;

--- a/src/lib/discord/help.ts
+++ b/src/lib/discord/help.ts
@@ -1,4 +1,5 @@
 import { config } from "@lib/config.js";
+import { orderAppliedTags } from "@lib/discord/tags.js";
 import { isTeamMember } from "@lib/discord/users.js";
 
 import {
@@ -41,11 +42,12 @@ export async function applyWaitingTag(
   if (alreadyCorrect) return;
 
   // Forum posts allow at most 5 tags. Keep the desired tag and drop the
-  // opposite one, trimming any overflow from the least recent tags.
-  const nextTags = [
+  // opposite one, ordering by the channel's tag configuration and trimming
+  // any overflow from the lowest-priority tags.
+  const nextTags = orderAppliedTags(thread, [
     desired,
     ...thread.appliedTags.filter((t) => t !== desired && t !== opposite),
-  ].slice(0, 5);
+  ]).slice(0, 5);
 
   await thread.setAppliedTags(nextTags, "Help post waiting state");
 }

--- a/src/lib/discord/tags.ts
+++ b/src/lib/discord/tags.ts
@@ -1,0 +1,23 @@
+import { ChannelType, type ThreadChannel } from "discord.js";
+
+// Discord renders a forum post's tags in the order of its applied_tags array
+// rather than the channel's configured tag order. Reorder applied tags to
+// follow the parent forum's tag configuration so status tags (open/closed),
+// which come first in the help channel settings, always lead the list.
+export function orderAppliedTags(
+  thread: ThreadChannel,
+  tags: string[],
+): string[] {
+  const parent = thread.parent;
+  const order =
+    parent?.type === ChannelType.GuildForum
+      ? parent.availableTags.map((tag) => tag.id)
+      : [];
+
+  const rank = (id: string) => {
+    const index = order.indexOf(id);
+    return index === -1 ? Number.MAX_SAFE_INTEGER : index;
+  };
+
+  return [...new Set(tags)].sort((a, b) => rank(a) - rank(b));
+}


### PR DESCRIPTION
## Problem

In the help forum, the `open`/`closed` status tags often render **last** on post cards instead of first, even though they are first in the channel tag settings.

Discord renders a forum post's tags in the order of the thread's `applied_tags` array, **not** the channel's configured tag order. The channel order only drives the tag picker and filter bar. Every codercord write path appended (or prepended something ahead of) the status tag:

- `lib/discord/help.ts` (`applyWaitingTag`) prepends `waiting-for-*` on every human message, pushing `open` toward the end. This is the main cause.
- `commands/util/walkthrough.ts` pushes `openedTag` at post creation.
- `commands/util/close.ts` (`handleIssueState`) pushes the state tag to the tail.
- `events/channels.ts` re-adds status tags with `[...appliedTags, tag]`.

## Fix

Add `orderAppliedTags(thread, tags)` in `src/lib/discord/tags.ts`. It sorts applied tags by their index in the parent forum's `availableTags` (the channel-configured order), so status tags stay first and the whole row mirrors settings. Unknown tags fall to the end; the result is de-duplicated. If the parent forum isn't resolvable it falls back to the input order (no-op).

Every `setAppliedTags` payload now runs through the helper.

<details>
<summary>Decision log</summary>

- Considered a lightweight helper that just pins `openedTag`/`closedTag` to the front. Chose the `availableTags`-based approach instead: it satisfies "open/closed first" (they are first in settings) and keeps the rest of the row consistent with the channel config, with no extra config to maintain.
- Kept the 5-tag `.slice(0, 5)` cap in `applyWaitingTag` after ordering; the waiting tags rank within the top 5 in settings, so they are never trimmed.
- `handleIssueState` now builds tags from a filtered copy instead of mutating the `appliedTags` getter array in place.
- Bot stays stateless: order is derived from Discord (`availableTags`) at call time, so it survives restarts.

</details>

## Testing

No test suite in the repo. Not runnable from my environment (no Bun workspace); please `bun format` / `bun lint` and smoke-test `/close`, `/reopen`, walkthrough, and a message-triggered waiting-tag update before merge.

---

_Opened by Coder Agents on behalf of @phorcys420._