### PR TITLE
feat(walkthrough): collapse the walkthrough into one edited message

### DIFF
--- a/src/commands/util/walkthrough.ts
+++ b/src/commands/util/walkthrough.ts
@@ -5,24 +5,16 @@ import { getCommandMention } from "@lib/discord/commands.js";
 import issueCategorySelector from "@components/issueCategorySelector.js";
 
 import {
+  ActionRowBuilder,
   type ChatInputCommandInteraction,
   type Client,
-  SlashCommandBuilder,
-  ActionRowBuilder,
-  type StringSelectMenuBuilder,
-  EmbedBuilder,
-  type Embed,
   Colors,
-  type PublicThreadChannel,
+  EmbedBuilder,
   type GuildTextBasedChannel,
-  ButtonBuilder,
-  ButtonStyle,
-  ContainerBuilder,
   MessageFlags,
-  SectionBuilder,
-  TextDisplayBuilder,
-  type MessageCreateOptions,
-  type InteractionReplyOptions,
+  type PublicThreadChannel,
+  SlashCommandBuilder,
+  type StringSelectMenuBuilder,
 } from "discord.js";
 
 type ResourceLink = { label: string; url: string };
@@ -46,56 +38,59 @@ export const productResources: Record<string, ResourceLink[]> = {
   ],
 };
 
-// Builds the walkthrough resources card. Given product resources it shows their
-// documentation links; otherwise it shows the post lifecycle commands, which is
-// what goes out as soon as the walkthrough starts.
-export async function buildResourcesMessage(
+// The data embed tracks the walkthrough answers. Its fields line up with the
+// walkthrough selectors (Category, Product, Platform) so each step can fill the
+// matching field in place.
+export function buildDataEmbed(channelId: string) {
+  return new EmbedBuilder().setTitle(`<#${channelId}>`).addFields([
+    { name: "Category", value: "N/A", inline: true },
+    { name: "Product", value: "N/A", inline: true },
+    { name: "Platform", value: "N/A", inline: true },
+    { name: "Logs", value: "Please post any relevant logs/error messages." },
+  ]);
+}
+
+// The resources embed always points at the post lifecycle commands and grows a
+// documentation link per product resource once the product is known.
+export async function buildResourcesEmbed(
   client: Client,
   resources: ResourceLink[],
 ) {
-  const container = new ContainerBuilder();
+  const embed = new EmbedBuilder()
+    .setColor(Colors.White)
+    .setDescription(
+      `When your issue is resolved, use ${await getCommandMention(client, "close")} to close this issue. Use ${await getCommandMention(client, "reopen")} to reopen it if needed.`,
+    );
 
   if (resources.length > 0) {
-    container.addSectionComponents(
-      resources.map((resource) =>
-        new SectionBuilder()
-          .addTextDisplayComponents(
-            new TextDisplayBuilder({ content: resource.label }),
-          )
-          .setButtonAccessory(
-            new ButtonBuilder()
-              .setStyle(ButtonStyle.Link)
-              .setLabel("Docs")
-              .setURL(resource.url),
-          ),
-      ),
-    );
-  } else {
-    container.addTextDisplayComponents(
-      new TextDisplayBuilder({
-        content: `When your issue is resolved, use ${await getCommandMention(client, "close")} to close this issue. Use ${await getCommandMention(client, "reopen")} to reopen it if needed.`,
-      }),
+    embed.addFields(
+      resources.map((resource) => ({
+        name: resource.label,
+        value: `[Docs](${resource.url})`,
+        inline: true,
+      })),
     );
   }
 
-  return {
-    flags: MessageFlags.IsComponentsV2,
-    components: [container],
-  };
+  return embed;
 }
 
-export function generateQuestion(
-  question: string,
-  component: StringSelectMenuBuilder,
-  embeds: (EmbedBuilder | Embed)[] = [],
-) {
+// A single walkthrough message: the data embed, the resources embed, the
+// current question, and the current selector. Every step edits this same
+// message instead of sending new ones.
+export async function buildWalkthroughMessage(channel: GuildTextBasedChannel) {
   return {
     embeds: [
-      ...embeds,
-      new EmbedBuilder().setColor(Colors.White).setDescription(question),
+      buildDataEmbed(channel.id),
+      await buildResourcesEmbed(channel.client, []),
+      new EmbedBuilder()
+        .setColor(Colors.White)
+        .setDescription("What are you creating this issue for?"),
     ],
     components: [
-      new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(component),
+      new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
+        issueCategorySelector,
+      ),
     ],
   };
 }
@@ -107,8 +102,6 @@ export async function doWalkthrough(
   if (await isHelpThread(channel)) {
     const threadChannel = channel as PublicThreadChannel; // necessary type cast, isHelpThread does the check already
 
-    const resourcesMessage = await buildResourcesMessage(channel.client, []);
-
     // Check for tags in the forum post
     const appliedTags = threadChannel.appliedTags ?? [];
     if (!appliedTags.includes(config.helpChannel.openedTag)) {
@@ -116,12 +109,13 @@ export async function doWalkthrough(
       threadChannel.setAppliedTags(appliedTags);
     }
 
-    // Send the resources message (or reply to the user if they're running the command)
+    const walkthroughMessage = await buildWalkthroughMessage(channel);
+
+    // Send the walkthrough message (or reply to the user if they're running the command)
     if (interaction) {
-      // TODO: also check for components V2, but wait until revamp
       // If the bot has sent a message that contains an embed in the first 30 messages, then we assume it's the walkthrough message
       const firstMessage = await threadChannel.fetchStarterMessage();
-      const walkthroughMessage = await threadChannel.messages
+      const existingWalkthrough = await threadChannel.messages
         .fetch({ around: firstMessage.id, limit: 30 })
         .then((messages) =>
           messages
@@ -133,27 +127,18 @@ export async function doWalkthrough(
             .at(0),
         );
 
-      if (walkthroughMessage) {
+      if (existingWalkthrough) {
         await interaction.reply({
-          content: `You cannot run the walkthrough command because a walkthrough already exists in this channel.\n(${walkthroughMessage.url})`,
+          content: `You cannot run the walkthrough command because a walkthrough already exists in this channel.\n(${existingWalkthrough.url})`,
           flags: MessageFlags.Ephemeral,
         });
         return;
       }
 
-      // TODO: fix the fact that it looks weird when the resources message is sent as a reply
-      await interaction.reply(resourcesMessage as InteractionReplyOptions);
+      await interaction.reply(walkthroughMessage);
     } else {
-      await channel.send(resourcesMessage as MessageCreateOptions);
+      await channel.send(walkthroughMessage);
     }
-
-    // Generate the walkthrough message asking the user what they're creating this issue for
-    const message = generateQuestion(
-      "What are you creating this issue for?",
-      issueCategorySelector,
-    );
-
-    return channel.send(message);
   }
 }
 

--- a/src/commands/util/walkthrough.ts
+++ b/src/commands/util/walkthrough.ts
@@ -3,14 +3,19 @@ import { config } from "@lib/config.js";
 import { isHelpPost as isHelpThread } from "@lib/discord/channels.js";
 import { getCommandMention } from "@lib/discord/commands.js";
 import issueCategorySelector from "@components/issueCategorySelector.js";
+import productSelector from "@components/productSelector.js";
 
 import {
   ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
   type ChatInputCommandInteraction,
   type Client,
   Colors,
+  type Embed,
   EmbedBuilder,
   type GuildTextBasedChannel,
+  type MessageActionRowComponentBuilder,
   MessageFlags,
   type PublicThreadChannel,
   SlashCommandBuilder,
@@ -19,9 +24,9 @@ import {
 
 type ResourceLink = { label: string; url: string };
 
-// Documentation resources keyed by product. Products without an entry (for
-// example code-server) simply get no resource links.
-export const productResources: Record<string, ResourceLink[]> = {
+// Documentation resources keyed by product value. Products without an entry
+// (for example code-server) simply get no resource links.
+const productResources: Record<string, ResourceLink[]> = {
   coder: [
     {
       label: "Where to find logs",
@@ -38,8 +43,16 @@ export const productResources: Record<string, ResourceLink[]> = {
   ],
 };
 
+// Resolves the resources for a product from the label shown in the data embed.
+function resourcesForProduct(productLabel: string): ResourceLink[] {
+  const option = productSelector.options.find(
+    (o) => o.data.label === productLabel,
+  );
+  return (option && productResources[option.data.value ?? ""]) || [];
+}
+
 // The data embed tracks the walkthrough answers. Its fields line up with the
-// walkthrough selectors (Category, Product, Platform) so each step can fill the
+// walkthrough selectors (Category, Product, Platform) so each step fills the
 // matching field in place.
 export function buildDataEmbed(channelId: string) {
   return new EmbedBuilder().setTitle(`<#${channelId}>`).addFields([
@@ -50,49 +63,55 @@ export function buildDataEmbed(channelId: string) {
   ]);
 }
 
-// The resources embed always points at the post lifecycle commands and grows a
-// documentation link per product resource once the product is known.
-export async function buildResourcesEmbed(
-  client: Client,
-  resources: ResourceLink[],
-) {
-  const embed = new EmbedBuilder()
+// The resources embed points users at the post lifecycle commands. It stays the
+// same for the whole walkthrough.
+export async function buildResourcesEmbed(client: Client) {
+  return new EmbedBuilder()
     .setColor(Colors.White)
     .setDescription(
       `When your issue is resolved, use ${await getCommandMention(client, "close")} to close this issue. Use ${await getCommandMention(client, "reopen")} to reopen it if needed.`,
     );
+}
 
-  if (resources.length > 0) {
-    embed.addFields(
-      resources.map((resource) => ({
-        name: resource.label,
-        value: `[Docs](${resource.url})`,
-        inline: true,
-      })),
+// Assembles the single walkthrough message from its current state: the data and
+// resources embeds, the current question and selector (while the walkthrough is
+// running), and a documentation button per resource of the selected product.
+export function buildWalkthroughMessage(
+  dataEmbed: EmbedBuilder,
+  resourcesEmbed: EmbedBuilder | Embed,
+  step?: { question: string; selector: StringSelectMenuBuilder },
+) {
+  const embeds: (EmbedBuilder | Embed)[] = [dataEmbed, resourcesEmbed];
+  const components: ActionRowBuilder<MessageActionRowComponentBuilder>[] = [];
+
+  if (step) {
+    embeds.push(
+      new EmbedBuilder().setColor(Colors.White).setDescription(step.question),
+    );
+    components.push(
+      new ActionRowBuilder<MessageActionRowComponentBuilder>().addComponents(
+        step.selector,
+      ),
     );
   }
 
-  return embed;
-}
-
-// A single walkthrough message: the data embed, the resources embed, the
-// current question, and the current selector. Every step edits this same
-// message instead of sending new ones.
-export async function buildWalkthroughMessage(channel: GuildTextBasedChannel) {
-  return {
-    embeds: [
-      buildDataEmbed(channel.id),
-      await buildResourcesEmbed(channel.client, []),
-      new EmbedBuilder()
-        .setColor(Colors.White)
-        .setDescription("What are you creating this issue for?"),
-    ],
-    components: [
-      new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
-        issueCategorySelector,
+  const resources = resourcesForProduct(
+    dataEmbed.data.fields?.[1]?.value ?? "",
+  );
+  if (resources.length > 0) {
+    components.push(
+      new ActionRowBuilder<MessageActionRowComponentBuilder>().addComponents(
+        resources.map((resource) =>
+          new ButtonBuilder()
+            .setStyle(ButtonStyle.Link)
+            .setLabel(resource.label)
+            .setURL(resource.url),
+        ),
       ),
-    ],
-  };
+    );
+  }
+
+  return { embeds, components };
 }
 
 export async function doWalkthrough(
@@ -109,7 +128,14 @@ export async function doWalkthrough(
       threadChannel.setAppliedTags(appliedTags);
     }
 
-    const walkthroughMessage = await buildWalkthroughMessage(channel);
+    const walkthroughMessage = buildWalkthroughMessage(
+      buildDataEmbed(channel.id),
+      await buildResourcesEmbed(channel.client),
+      {
+        question: "What are you creating this issue for?",
+        selector: issueCategorySelector,
+      },
+    );
 
     // Send the walkthrough message (or reply to the user if they're running the command)
     if (interaction) {

--- a/src/events/walkthrough.ts
+++ b/src/events/walkthrough.ts
@@ -1,22 +1,13 @@
 import {
-  buildResourcesEmbed,
+  buildWalkthroughMessage,
   doWalkthrough,
-  productResources,
 } from "@commands/util/walkthrough.js";
 
 import issueCategorySelector from "@components/issueCategorySelector.js";
 import productSelector from "@components/productSelector.js";
 import operatingSystemFamilySelector from "@components/operatingSystemFamilySelector.js";
 
-import {
-  ActionRowBuilder,
-  type Client,
-  Colors,
-  EmbedBuilder,
-  Events,
-  type InteractionUpdateOptions,
-  type StringSelectMenuBuilder,
-} from "discord.js";
+import { type Client, EmbedBuilder, Events } from "discord.js";
 
 // This has to follow the order of the walkthrough steps
 const selectors = [
@@ -34,8 +25,7 @@ export default function registerEvents(client: Client) {
   // Do walkthrough whenever a thread is opened
   client.on(Events.ThreadCreate, async (channel) => doWalkthrough(channel));
 
-  // Each selection edits the single walkthrough message in place. Its embeds
-  // are [data, resources, question].
+  // Each selection edits the single walkthrough message in place.
   client.on(Events.InteractionCreate, async (interaction) => {
     if (!interaction.isStringSelectMenu()) {
       return;
@@ -52,48 +42,26 @@ export default function registerEvents(client: Client) {
     const lastStep = index + 1 === selectors.length;
 
     // Fill the answered field in the data embed with its human-readable label.
-    const dataEmbed = interaction.message.embeds[0];
-    dataEmbed.fields[index].value = getLabelFromValue(
+    const dataEmbed = EmbedBuilder.from(interaction.message.embeds[0]);
+    dataEmbed.data.fields[index].value = getLabelFromValue(
       interaction.values[0],
       selector,
     );
 
-    // Rebuild the resources embed once the product is picked so its
-    // documentation links match the chosen product.
-    let resourcesEmbed = EmbedBuilder.from(interaction.message.embeds[1]);
-    if (selector === productSelector) {
-      resourcesEmbed = await buildResourcesEmbed(
-        interaction.client,
-        productResources[interaction.values[0]] ?? [],
-      );
-    }
+    const nextSelector = selectors[index + 1];
+    const step = lastStep
+      ? undefined
+      : {
+          question:
+            nextSelector === productSelector
+              ? "What product are you using?"
+              : `What operating system are you running ${dataEmbed.data.fields[index].value} on?`,
+          selector: nextSelector,
+        };
 
-    let messageData: InteractionUpdateOptions;
-
-    if (lastStep) {
-      messageData = { embeds: [dataEmbed, resourcesEmbed], components: [] };
-    } else {
-      const nextSelector = selectors[index + 1];
-      const question =
-        nextSelector === productSelector
-          ? "What product are you using?"
-          : `What operating system are you running ${dataEmbed.fields[index].value} on?`;
-
-      messageData = {
-        embeds: [
-          dataEmbed,
-          resourcesEmbed,
-          new EmbedBuilder().setColor(Colors.White).setDescription(question),
-        ],
-        components: [
-          new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
-            nextSelector,
-          ),
-        ],
-      };
-    }
-
-    await interaction.update(messageData);
+    await interaction.update(
+      buildWalkthroughMessage(dataEmbed, interaction.message.embeds[1], step),
+    );
 
     // If this is the last step of the walkthrough, we pin the message
     if (lastStep) {

--- a/src/events/walkthrough.ts
+++ b/src/events/walkthrough.ts
@@ -1,7 +1,6 @@
 import {
-  buildResourcesMessage,
+  buildResourcesEmbed,
   doWalkthrough,
-  generateQuestion,
   productResources,
 } from "@commands/util/walkthrough.js";
 
@@ -10,11 +9,13 @@ import productSelector from "@components/productSelector.js";
 import operatingSystemFamilySelector from "@components/operatingSystemFamilySelector.js";
 
 import {
+  ActionRowBuilder,
   type Client,
+  Colors,
   EmbedBuilder,
   Events,
   type InteractionUpdateOptions,
-  type MessageCreateOptions,
+  type StringSelectMenuBuilder,
 } from "discord.js";
 
 // This has to follow the order of the walkthrough steps
@@ -29,87 +30,74 @@ function getLabelFromValue(value, selector: (typeof selectors)[number]) {
     .data.label;
 }
 
-// TODO: make this readable
 export default function registerEvents(client: Client) {
   // Do walkthrough whenever a thread is opened
   client.on(Events.ThreadCreate, async (channel) => doWalkthrough(channel));
 
-  // Register events for the actual walkthrough steps
+  // Each selection edits the single walkthrough message in place. Its embeds
+  // are [data, resources, question].
   client.on(Events.InteractionCreate, async (interaction) => {
-    if (interaction.isStringSelectMenu()) {
-      let messageData: InteractionUpdateOptions;
+    if (!interaction.isStringSelectMenu()) {
+      return;
+    }
 
-      const selector = selectors.filter(
-        (element) => element.data.custom_id === interaction.customId,
-      )[0];
-      const index = selectors.indexOf(selector);
+    const selector = selectors.find(
+      (element) => element.data.custom_id === interaction.customId,
+    );
+    if (!selector) {
+      return;
+    }
 
-      const lastStep = index + 1 === selectors.length;
+    const index = selectors.indexOf(selector);
+    const lastStep = index + 1 === selectors.length;
 
-      if (index === 0) {
-        const dataEmbed = new EmbedBuilder()
-          .setTitle(`<#${interaction.channelId}>`)
-          .addFields([
-            {
-              name: "Category",
-              value: getLabelFromValue(interaction.values[0], selector),
-              inline: true,
-            },
-            { name: "Product", value: "N/A", inline: true },
-            { name: "Platform", value: "N/A", inline: true },
-            {
-              name: "Logs",
-              value: "Please post any relevant logs/error messages.",
-            },
-          ]);
+    // Fill the answered field in the data embed with its human-readable label.
+    const dataEmbed = interaction.message.embeds[0];
+    dataEmbed.fields[index].value = getLabelFromValue(
+      interaction.values[0],
+      selector,
+    );
 
-        messageData = generateQuestion(
-          "What product are you using?",
-          productSelector,
-          [dataEmbed],
-        );
-      } else {
-        // Grab the embed from the last message and edit the corresponding field with the human-readable field (instead of the ID)
-        const dataEmbed = interaction.message.embeds[0];
-        dataEmbed.fields[index].value = getLabelFromValue(
-          interaction.values[0],
-          selector,
-        );
+    // Rebuild the resources embed once the product is picked so its
+    // documentation links match the chosen product.
+    let resourcesEmbed = EmbedBuilder.from(interaction.message.embeds[1]);
+    if (selector === productSelector) {
+      resourcesEmbed = await buildResourcesEmbed(
+        interaction.client,
+        productResources[interaction.values[0]] ?? [],
+      );
+    }
 
-        // TODO : make this part more generic once we have more questions
-        if (selector === productSelector) {
-          messageData = generateQuestion(
-            `What operating system are you running ${dataEmbed.fields[index].value} on?`,
-            selectors[index + 1], // next selector
-            [dataEmbed],
-          );
-        } else if (lastStep) {
-          // This is the last step of the walkthrough, so we generate an empty message with just the data embed
-          messageData = { components: [], embeds: [dataEmbed] };
-        } else {
-          throw new Error("No case matches this walkthrough step");
-        }
-      }
+    let messageData: InteractionUpdateOptions;
 
-      await interaction.update(messageData);
+    if (lastStep) {
+      messageData = { embeds: [dataEmbed, resourcesEmbed], components: [] };
+    } else {
+      const nextSelector = selectors[index + 1];
+      const question =
+        nextSelector === productSelector
+          ? "What product are you using?"
+          : `What operating system are you running ${dataEmbed.fields[index].value} on?`;
 
-      // Post the product's documentation resources, if any exist for it.
-      if (selector === productSelector) {
-        const resources = productResources[interaction.values[0]];
-        if (resources) {
-          await interaction.channel.send(
-            (await buildResourcesMessage(
-              interaction.client,
-              resources,
-            )) as MessageCreateOptions,
-          );
-        }
-      }
+      messageData = {
+        embeds: [
+          dataEmbed,
+          resourcesEmbed,
+          new EmbedBuilder().setColor(Colors.White).setDescription(question),
+        ],
+        components: [
+          new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
+            nextSelector,
+          ),
+        ],
+      };
+    }
 
-      // If this is the last step of the walkthrough, we pin the message
-      if (lastStep) {
-        await interaction.message.pin();
-      }
+    await interaction.update(messageData);
+
+    // If this is the last step of the walkthrough, we pin the message
+    if (lastStep) {
+      await interaction.message.pin();
     }
   });
 }


### PR DESCRIPTION
## What

The walkthrough was sending three separate messages (lifecycle `/close`+`/reopen`, the Q&A embed, and the product resources card). This collapses them into a single message that is edited in place through the flow.

## How

- `doWalkthrough` now posts one message with three embeds and the first selector:
  1. **Data embed** (Category / Product / Platform / Logs), fields start at `N/A`.
  2. **Resources embed** (the dynamic second embed): always shows the `/close` + `/reopen` lifecycle commands, and gains a `[Docs]` link field per product resource once the product is known.
  3. **Question embed** for the current step.
- Each selection calls `interaction.update` on that same message: it fills the answered field, rebuilds the resources embed on the product step (Coder gets doc links, code-server gets none), swaps in the next question/selector, and on the last step drops the question + selector and pins.
- Product resource links are now embed fields (`[Docs](url)`) instead of a separate Components V2 card, so everything lives in one message.

---
_Opened by Coder Agents on behalf of @phorcys420._