### PR TITLE
fix(commands/util/close): line break before the reopen hint

### DIFF
--- a/src/commands/util/close.ts
+++ b/src/commands/util/close.ts
@@ -59,7 +59,7 @@ export async function handleIssueState(
 
     const reopenHint =
       close && !lock
-        ? ` You can reopen this issue by doing ${await getCommandMention(
+        ? `\nYou can reopen this issue by doing ${await getCommandMention(
             interaction.client,
             "reopen",
           )}.`


### PR DESCRIPTION
Puts the reopen hint on its own line so the `/close` reply reads:

> @user closed the thread.
> You can reopen this issue by doing `/reopen`.

The hint is still only shown when closing without locking.

---
_Opened by Coder Agents on behalf of @phorcys420._