### PR TITLE
chore: move to alpine-based bun image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1 AS base
+FROM oven/bun:1-alpine AS base
 
 WORKDIR /usr/src/app
 COPY . .


### PR DESCRIPTION
Closes #20.

Switches the Docker base image from `oven/bun:1` to `oven/bun:1-alpine` for a smaller image.

---

*This PR was generated by Coder Agents on behalf of @phorcys420.*